### PR TITLE
Fix type of argv class member

### DIFF
--- a/src/headers/traj.h
+++ b/src/headers/traj.h
@@ -1846,7 +1846,7 @@ class Trajectory
         void        parallelize_by_water(int num_waters_1);                                             //distribute workload by waters
         void        workload_water();                                                                   //prints the workload distribution for waters
 
-        const char * argv[];                          //The command line arguments
+        const char **argv;                          //The command line arguments
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The declaration `const char * argv[]` is legal for a function argument, but not for a class member.  Recent compilers (e.g. GCC 11) will raise an error. This change fixes this by declaring `argv` as a pointer type.

You may also want to declare it as a `std::vector<std::string>`, and populate it in `Trajectory::set_input_arguments()` (safer than copying the `char` pointers).

Edit: Fixes #1 (I just noticed it after opening this PR when I saw the problem on my own)